### PR TITLE
Shade com.google.auth

### DIFF
--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -57,6 +57,7 @@ shadowJar {
     relocate 'com.google.protobuf', 'datalineage.shaded.com.google.protobuf'
     relocate 'com.google.guava', 'datalineage.shaded.com.google.guava'
     relocate 'com.google.api', 'datalineage.shaded.com.google.api'
+    relocate 'com.google.auth', 'datalineage.shaded.com.google.auth'
     relocate 'io.grpc', 'datalineage.shaded.io.grpc'
     relocate 'com.google.common', 'datalineage.shaded.com.google.common'
     relocate 'com.google.gson', 'datalineage.shaded.com.google.gson'


### PR DESCRIPTION
This shading is required to avoid this error:

```
com.google.auth.http.HttpTransportFactory.create()Lcom/google/api/client/http/HttpTransport;
java.lang.NoSuchMethodError: com.google.auth.http.HttpTransportFactory.create()Lcom/google/api/client/http/HttpTransport;
	at com.google.cloud.bigquery.spi.v2.HttpBigQueryRpc.<init>(HttpBigQueryRpc.java:105)
	at com.google.cloud.bigquery.BigQueryOptions$DefaultBigQueryRpcFactory.create(BigQueryOptions.java:59)
	at com.google.cloud.bigquery.BigQueryOptions$DefaultBigQueryRpcFactory.create(BigQueryOptions.java:53)
	at com.google.cloud.ServiceOptions.getRpc(ServiceOptions.java:602)
	at com.google.cloud.bigquery.BigQueryOptions.getBigQueryRpcV2(BigQueryOptions.java:128)
	at com.google.cloud.bigquery.BigQueryImpl.<init>(BigQueryImpl.java:256)
	at com.google.cloud.bigquery.BigQueryOptions$DefaultBigQueryFactory.create(BigQueryOptions.java:49)
	at com.google.cloud.bigquery.BigQueryOptions$DefaultBigQueryFactory.create(BigQueryOptions.java:43)
	at com.google.cloud.ServiceOptions.getService(ServiceOptions.java:582)
	...
```