### PR TITLE
implement graceful shutdown in async producer

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,56 @@ Or, for a shadow jar:
 ```
 
 The output will be located at `lib/build/libs`.
+
+## Logging
+
+This library uses [SLF4J](https://www.slf4j.org/) for logging. To see log output, you need to include an SLF4J binding in your application dependencies.
+
+### Adding a logging implementation
+
+For Logback (recommended):
+```xml
+<dependency>
+    <groupId>ch.qos.logback</groupId>
+    <artifactId>logback-classic</artifactId>
+    <version>1.4.14</version>
+</dependency>
+```
+
+For Log4j2:
+```xml
+<dependency>
+    <groupId>org.apache.logging.log4j</groupId>
+    <artifactId>log4j-slf4j2-impl</artifactId>
+    <version>2.20.0</version>
+</dependency>
+```
+
+### Configuring log levels
+
+The library logs at different levels:
+- **INFO**: Client creation, cache initialization, shutdown events
+- **WARN**: Service disruptions, graceful shutdown timeouts, API errors
+- **DEBUG**: Detailed API call information, cache operations
+
+Example Logback configuration (`logback.xml`):
+```xml
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <!-- Set debug level for data lineage producer client -->
+    <logger name="com.google.cloud.datalineage.producerclient" level="DEBUG"/>
+    
+    <root level="INFO">
+        <appender-ref ref="STDOUT"/>
+    </root>
+</configuration>
+```
+
 ## Performing calls
 To perform a call, you need to:
 1. Create a client

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -37,6 +37,8 @@ ext {
     truthVersion = '1.1.3'
     mockitoVersion = '3.+'
     parameterInjectorVersion = '1.8'
+    slf4jVersion = '2.0.9'
+    logbackVersion = '1.4.14'
 }
 
 repositories {
@@ -54,12 +56,20 @@ dependencies {
     implementation "com.google.api:gax-httpjson:${gaxHttpJsonVersion}"
     implementation "io.grpc:grpc-protobuf:${grpcProtobufVersion}"
     implementation "com.google.guava:guava:${guavaVersion}"
+    
+    // SLF4J logging
+    implementation "org.slf4j:slf4j-api:${slf4jVersion}"
+    
     // Use JUnit test framework.
     testImplementation "junit:junit:${junitVersion}"
     testImplementation "com.google.truth:truth:${truthVersion}"
     testImplementation "org.mockito:mockito-core:${mockitoVersion}"
     testImplementation "com.google.api:gax:${gaxTestLibVersion}:testlib"
     testImplementation "com.google.testparameterinjector:test-parameter-injector:${parameterInjectorVersion}"
+    
+    // Test logging dependencies
+    testImplementation "ch.qos.logback:logback-classic:${logbackVersion}"
+    testImplementation "ch.qos.logback:logback-core:${logbackVersion}"
 }
 
 test {

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -39,6 +39,7 @@ ext {
     parameterInjectorVersion = '1.8'
     slf4jVersion = '2.0.9'
     logbackVersion = '1.4.14'
+    lombokVersion = '1.18.30'
 }
 
 repositories {
@@ -60,6 +61,10 @@ dependencies {
     // SLF4J logging
     implementation "org.slf4j:slf4j-api:${slf4jVersion}"
     
+    // Lombok for @Slf4j annotation
+    compileOnly "org.projectlombok:lombok:${lombokVersion}"
+    annotationProcessor "org.projectlombok:lombok:${lombokVersion}"
+    
     // Use JUnit test framework.
     testImplementation "junit:junit:${junitVersion}"
     testImplementation "com.google.truth:truth:${truthVersion}"
@@ -70,6 +75,10 @@ dependencies {
     // Test logging dependencies
     testImplementation "ch.qos.logback:logback-classic:${logbackVersion}"
     testImplementation "ch.qos.logback:logback-core:${logbackVersion}"
+    
+    // Test Lombok
+    testCompileOnly "org.projectlombok:lombok:${lombokVersion}"
+    testAnnotationProcessor "org.projectlombok:lombok:${lombokVersion}"
 }
 
 test {

--- a/lib/src/main/java/com/google/cloud/datalineage/producerclient/StandardApiEnablementCache.java
+++ b/lib/src/main/java/com/google/cloud/datalineage/producerclient/StandardApiEnablementCache.java
@@ -34,13 +34,11 @@ public class StandardApiEnablementCache implements ApiEnablementCache {
   private final Clock clock;
 
   StandardApiEnablementCache(ApiEnablementCacheOptions options) {
-    if (log.isDebugEnabled()) {
-      log.debug(
-          "Initializing StandardApiEnablementCache with cache size: {}, "
-              + "default disabled duration: {}",
-          options.getCacheSize(),
-          options.getDefaultCacheDisabledStatusTime());
-    }
+    log.debug(
+        "Initializing StandardApiEnablementCache with cache size: {}, "
+            + "default disabled duration: {}",
+        options.getCacheSize(),
+        options.getDefaultCacheDisabledStatusTime());
     defaultCacheDisabledStatusTime = options.getDefaultCacheDisabledStatusTime();
     clock = options.getClock();
 

--- a/lib/src/main/java/com/google/cloud/datalineage/producerclient/StandardApiEnablementCache.java
+++ b/lib/src/main/java/com/google/cloud/datalineage/producerclient/StandardApiEnablementCache.java
@@ -34,12 +34,12 @@ public class StandardApiEnablementCache implements ApiEnablementCache {
   private final Clock clock;
 
   StandardApiEnablementCache(ApiEnablementCacheOptions options) {
-    if (log.isDebugEnabled()){
+    if (log.isDebugEnabled()) {
       log.debug(
-              "Initializing StandardApiEnablementCache with cache size: {}, "
-                      + "default disabled duration: {}",
-              options.getCacheSize(),
-              options.getDefaultCacheDisabledStatusTime());
+          "Initializing StandardApiEnablementCache with cache size: {}, "
+              + "default disabled duration: {}",
+          options.getCacheSize(),
+          options.getDefaultCacheDisabledStatusTime());
     }
     defaultCacheDisabledStatusTime = options.getDefaultCacheDisabledStatusTime();
     clock = options.getClock();

--- a/lib/src/main/java/com/google/cloud/datalineage/producerclient/v1/AsyncLineageProducerClient.java
+++ b/lib/src/main/java/com/google/cloud/datalineage/producerclient/v1/AsyncLineageProducerClient.java
@@ -38,8 +38,7 @@ import com.google.cloud.datacatalog.lineage.v1.Run;
 import com.google.protobuf.Empty;
 import java.io.IOException;
 import java.util.concurrent.TimeUnit;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import lombok.extern.slf4j.Slf4j;
 import org.threeten.bp.Duration;
 import org.threeten.bp.Instant;
 
@@ -49,9 +48,8 @@ import org.threeten.bp.Instant;
  * <p>Implements AsyncLineageClient using client library. This implementation also provides support
  * for connection cache.
  */
+@Slf4j
 public final class AsyncLineageProducerClient implements BackgroundResource, AsyncLineageClient {
-
-  private static final Logger logger = LoggerFactory.getLogger(AsyncLineageProducerClient.class);
 
   public static AsyncLineageProducerClient create() throws IOException {
     return create(AsyncLineageProducerClientSettings.newBuilder().build());
@@ -59,7 +57,7 @@ public final class AsyncLineageProducerClient implements BackgroundResource, Asy
 
   public static AsyncLineageProducerClient create(AsyncLineageProducerClientSettings settings)
       throws IOException {
-    logger.debug(
+    log.debug(
         "Creating AsyncLineageProducerClient with graceful shutdown duration: {}",
         settings.getGracefulShutdownDuration());
     return new AsyncLineageProducerClient(settings);
@@ -91,48 +89,48 @@ public final class AsyncLineageProducerClient implements BackgroundResource, Asy
 
   @Override
   public ApiFuture<Empty> deleteLineageEvent(DeleteLineageEventRequest request) {
-    if (logger.isDebugEnabled()) {
-      logger.debug("Deleting lineage event: {}", request.getName());
+    if (log.isDebugEnabled()) {
+      log.debug("Deleting lineage event: {}", request.getName());
     }
     return client.deleteLineageEvent(request);
   }
 
   @Override
   public OperationFuture<Empty, OperationMetadata> deleteProcess(DeleteProcessRequest request) {
-    if (logger.isDebugEnabled()) {
-      logger.debug("Deleting process: {}", request.getName());
+    if (log.isDebugEnabled()) {
+      log.debug("Deleting process: {}", request.getName());
     }
     return client.deleteProcess(request);
   }
 
   @Override
   public OperationFuture<Empty, OperationMetadata> deleteRun(DeleteRunRequest request) {
-    if (logger.isDebugEnabled()) {
-      logger.debug("Deleting run: {}", request.getName());
+    if (log.isDebugEnabled()) {
+      log.debug("Deleting run: {}", request.getName());
     }
     return client.deleteRun(request);
   }
 
   @Override
   public ApiFuture<LineageEvent> getLineageEvent(GetLineageEventRequest request) {
-    if (logger.isDebugEnabled()) {
-      logger.debug("Getting lineage event: {}", request.getName());
+    if (log.isDebugEnabled()) {
+      log.debug("Getting lineage event: {}", request.getName());
     }
     return client.getLineageEvent(request);
   }
 
   @Override
   public ApiFuture<Process> getProcess(GetProcessRequest request) {
-    if (logger.isDebugEnabled()) {
-      logger.debug("Getting process: {}", request.getName());
+    if (log.isDebugEnabled()) {
+      log.debug("Getting process: {}", request.getName());
     }
     return client.getProcess(request);
   }
 
   @Override
   public ApiFuture<Run> getRun(GetRunRequest request) {
-    if (logger.isDebugEnabled()) {
-      logger.debug("Getting run: {}", request.getName());
+    if (log.isDebugEnabled()) {
+      log.debug("Getting run: {}", request.getName());
     }
     return client.getRun(request);
   }
@@ -140,24 +138,24 @@ public final class AsyncLineageProducerClient implements BackgroundResource, Asy
   @Override
   public ApiFuture<ListLineageEventsPagedResponse> listLineageEvents(
       ListLineageEventsRequest request) {
-    if (logger.isDebugEnabled()) {
-      logger.debug("Listing lineage events for request: {}", request);
+    if (log.isDebugEnabled()) {
+      log.debug("Listing lineage events for request: {}", request);
     }
     return client.listLineageEvents(request);
   }
 
   @Override
   public ApiFuture<ListProcessesPagedResponse> listProcesses(ListProcessesRequest request) {
-    if (logger.isDebugEnabled()) {
-      logger.debug("Listing processes for request: {}", request);
+    if (log.isDebugEnabled()) {
+      log.debug("Listing processes for request: {}", request);
     }
     return client.listProcesses(request);
   }
 
   @Override
   public ApiFuture<ListRunsPagedResponse> listRuns(ListRunsRequest request) {
-    if (logger.isDebugEnabled()) {
-      logger.debug("Listing runs for request: {}", request);
+    if (log.isDebugEnabled()) {
+      log.debug("Listing runs for request: {}", request);
     }
     return client.listRuns(request);
   }
@@ -165,8 +163,8 @@ public final class AsyncLineageProducerClient implements BackgroundResource, Asy
   @Override
   public ApiFuture<ProcessOpenLineageRunEventResponse> processOpenLineageRunEvent(
       ProcessOpenLineageRunEventRequest request) {
-    if (logger.isDebugEnabled()) {
-      logger.debug("Processing OpenLineage run event: {}", request.getOpenLineage());
+    if (log.isDebugEnabled()) {
+      log.debug("Processing OpenLineage run event: {}", request.getOpenLineage());
     }
     return client.processOpenLineageRunEvent(request);
   }
@@ -185,7 +183,7 @@ public final class AsyncLineageProducerClient implements BackgroundResource, Asy
     try {
       gracefulShutdown(start);
     } catch (InterruptedException e) {
-      logger.warn("Interrupted during shutdown", e);
+      log.warn("Interrupted during shutdown", e);
     }
   }
 
@@ -211,16 +209,17 @@ public final class AsyncLineageProducerClient implements BackgroundResource, Asy
 
   private void gracefulShutdown(Instant start) throws InterruptedException {
     if (!gracefulShutdownDuration.isZero()) {
-      if (logger.isDebugEnabled()) {
-        logger.debug("Starting graceful shutdown with duration: {}", gracefulShutdownDuration);
+      if (log.isDebugEnabled()) {
+        log.debug("Starting graceful shutdown with duration: {}", gracefulShutdownDuration);
       }
       boolean terminated =
           awaitTermination(
               gracefulShutdownDuration.minus(Duration.between(start, Instant.now())).toNanos(),
               TimeUnit.NANOSECONDS);
       if (!terminated) {
-        logger.warn(
-            "AsyncLineageProducerClient did not terminate within the graceful shutdown duration: {}",
+        log.warn(
+            "AsyncLineageProducerClient did not terminate within the "
+                + "graceful shutdown duration: {}",
             gracefulShutdownDuration);
       }
     }

--- a/lib/src/main/java/com/google/cloud/datalineage/producerclient/v1/AsyncLineageProducerClient.java
+++ b/lib/src/main/java/com/google/cloud/datalineage/producerclient/v1/AsyncLineageProducerClient.java
@@ -89,83 +89,63 @@ public final class AsyncLineageProducerClient implements BackgroundResource, Asy
 
   @Override
   public ApiFuture<Empty> deleteLineageEvent(DeleteLineageEventRequest request) {
-    if (log.isDebugEnabled()) {
-      log.debug("Deleting lineage event: {}", request.getName());
-    }
+    log.debug("Deleting lineage event: {}", request.getName());
     return client.deleteLineageEvent(request);
   }
 
   @Override
   public OperationFuture<Empty, OperationMetadata> deleteProcess(DeleteProcessRequest request) {
-    if (log.isDebugEnabled()) {
-      log.debug("Deleting process: {}", request.getName());
-    }
+    log.debug("Deleting process: {}", request.getName());
     return client.deleteProcess(request);
   }
 
   @Override
   public OperationFuture<Empty, OperationMetadata> deleteRun(DeleteRunRequest request) {
-    if (log.isDebugEnabled()) {
-      log.debug("Deleting run: {}", request.getName());
-    }
+    log.debug("Deleting run: {}", request.getName());
     return client.deleteRun(request);
   }
 
   @Override
   public ApiFuture<LineageEvent> getLineageEvent(GetLineageEventRequest request) {
-    if (log.isDebugEnabled()) {
-      log.debug("Getting lineage event: {}", request.getName());
-    }
+    log.debug("Getting lineage event: {}", request.getName());
     return client.getLineageEvent(request);
   }
 
   @Override
   public ApiFuture<Process> getProcess(GetProcessRequest request) {
-    if (log.isDebugEnabled()) {
-      log.debug("Getting process: {}", request.getName());
-    }
+    log.debug("Getting process: {}", request.getName());
     return client.getProcess(request);
   }
 
   @Override
   public ApiFuture<Run> getRun(GetRunRequest request) {
-    if (log.isDebugEnabled()) {
-      log.debug("Getting run: {}", request.getName());
-    }
+    log.debug("Getting run: {}", request.getName());
     return client.getRun(request);
   }
 
   @Override
   public ApiFuture<ListLineageEventsPagedResponse> listLineageEvents(
       ListLineageEventsRequest request) {
-    if (log.isDebugEnabled()) {
-      log.debug("Listing lineage events for request: {}", request);
-    }
+    log.debug("Listing lineage events for parent: {}", request.getParent());
     return client.listLineageEvents(request);
   }
 
   @Override
   public ApiFuture<ListProcessesPagedResponse> listProcesses(ListProcessesRequest request) {
-    if (log.isDebugEnabled()) {
-      log.debug("Listing processes for request: {}", request);
-    }
+    log.debug("Listing processes for parent: {}", request.getParent());
     return client.listProcesses(request);
   }
 
   @Override
   public ApiFuture<ListRunsPagedResponse> listRuns(ListRunsRequest request) {
-    if (log.isDebugEnabled()) {
-      log.debug("Listing runs for request: {}", request);
-    }
+    log.debug("Listing runs for parent: {}", request.getParent());
     return client.listRuns(request);
   }
 
   @Override
   public ApiFuture<ProcessOpenLineageRunEventResponse> processOpenLineageRunEvent(
       ProcessOpenLineageRunEventRequest request) {
-    if (log.isDebugEnabled()) {
-      log.debug("Processing OpenLineage run event: {}", request.getOpenLineage());
-    }
+    log.debug("Processing OpenLineage run event: {}", request.getOpenLineage());
     return client.processOpenLineageRunEvent(request);
   }
 
@@ -209,9 +189,7 @@ public final class AsyncLineageProducerClient implements BackgroundResource, Asy
 
   private void gracefulShutdown(Instant start) throws InterruptedException {
     if (!gracefulShutdownDuration.isZero()) {
-      if (log.isDebugEnabled()) {
-        log.debug("Starting graceful shutdown with duration: {}", gracefulShutdownDuration);
-      }
+      log.debug("Starting graceful shutdown with duration: {}", gracefulShutdownDuration);
       boolean terminated =
           awaitTermination(
               gracefulShutdownDuration.minus(Duration.between(start, Instant.now())).toNanos(),

--- a/lib/src/main/java/com/google/cloud/datalineage/producerclient/v1/AsyncLineageProducerClientSettings.java
+++ b/lib/src/main/java/com/google/cloud/datalineage/producerclient/v1/AsyncLineageProducerClientSettings.java
@@ -24,6 +24,7 @@ import com.google.api.gax.rpc.WatchdogProvider;
 import com.google.cloud.datacatalog.lineage.v1.stub.LineageStubSettings;
 import com.google.cloud.datalineage.producerclient.ApiEnablementCacheSettings;
 import java.io.IOException;
+import java.util.concurrent.TimeUnit;
 import javax.annotation.Nullable;
 import org.threeten.bp.Duration;
 
@@ -32,6 +33,8 @@ import org.threeten.bp.Duration;
  * via Builder.
  */
 public final class AsyncLineageProducerClientSettings extends LineageBaseSettings {
+  private final Long gracefulShutdownDuration;
+  private final TimeUnit gracefulShutdownUnit;
 
   public static Builder newBuilder() {
     return Builder.createDefault();
@@ -47,6 +50,16 @@ public final class AsyncLineageProducerClientSettings extends LineageBaseSetting
 
   private AsyncLineageProducerClientSettings(Builder settingsBuilder) throws IOException {
     super(settingsBuilder);
+    this.gracefulShutdownDuration = settingsBuilder.gracefulShutdownDuration;
+    this.gracefulShutdownUnit = settingsBuilder.gracefulShutdownUnit;
+  }
+
+  public Long getGracefulShutdownDuration() {
+    return gracefulShutdownDuration;
+  }
+
+  public TimeUnit getGracefulShutdownUnit() {
+    return gracefulShutdownUnit;
   }
 
   /**
@@ -57,7 +70,8 @@ public final class AsyncLineageProducerClientSettings extends LineageBaseSetting
    * method.
    */
   public static final class Builder extends LineageBaseSettings.Builder {
-
+    private Long gracefulShutdownDuration = 0L;
+    private TimeUnit gracefulShutdownUnit = TimeUnit.NANOSECONDS;
     private static Builder createDefault() {
       return new Builder(LineageStubSettings.newBuilder());
     }
@@ -68,6 +82,8 @@ public final class AsyncLineageProducerClientSettings extends LineageBaseSetting
 
     Builder(AsyncLineageProducerClientSettings settings) {
       super(settings);
+      this.gracefulShutdownDuration = settings.gracefulShutdownDuration;
+      this.gracefulShutdownUnit = settings.gracefulShutdownUnit;
     }
 
     Builder(LineageStubSettings.Builder stubSettings) {
@@ -83,6 +99,24 @@ public final class AsyncLineageProducerClientSettings extends LineageBaseSetting
     public SyncLineageProducerClientSettings.Builder setConnectionCacheSettings(
         ApiEnablementCacheSettings settings) {
       return (SyncLineageProducerClientSettings.Builder) super.setConnectionCacheSettings(settings);
+    }
+
+    public Builder setGracefulShutdownDuration(Long gracefulShutdownDuration) {
+      this.gracefulShutdownDuration = gracefulShutdownDuration;
+      return this;
+    }
+
+    public Builder setGracefulShutdownTimeUnit(TimeUnit gracefulShutdownUnit) {
+      this.gracefulShutdownUnit = gracefulShutdownUnit;
+      return this;
+    }
+
+    public Long getGracefulShutdownDuration() {
+      return gracefulShutdownDuration;
+    }
+
+    public TimeUnit getGracefulShutdownUnit() {
+      return gracefulShutdownUnit;
     }
 
     @Override

--- a/lib/src/main/java/com/google/cloud/datalineage/producerclient/v1/AsyncLineageProducerClientSettings.java
+++ b/lib/src/main/java/com/google/cloud/datalineage/producerclient/v1/AsyncLineageProducerClientSettings.java
@@ -24,7 +24,6 @@ import com.google.api.gax.rpc.WatchdogProvider;
 import com.google.cloud.datacatalog.lineage.v1.stub.LineageStubSettings;
 import com.google.cloud.datalineage.producerclient.ApiEnablementCacheSettings;
 import java.io.IOException;
-import java.util.concurrent.TimeUnit;
 import javax.annotation.Nullable;
 import org.threeten.bp.Duration;
 
@@ -33,8 +32,7 @@ import org.threeten.bp.Duration;
  * via Builder.
  */
 public final class AsyncLineageProducerClientSettings extends LineageBaseSettings {
-  private final Long gracefulShutdownDuration;
-  private final TimeUnit gracefulShutdownUnit;
+  private final Duration gracefulShutdownDuration;
 
   public static Builder newBuilder() {
     return Builder.createDefault();
@@ -51,15 +49,10 @@ public final class AsyncLineageProducerClientSettings extends LineageBaseSetting
   private AsyncLineageProducerClientSettings(Builder settingsBuilder) throws IOException {
     super(settingsBuilder);
     this.gracefulShutdownDuration = settingsBuilder.gracefulShutdownDuration;
-    this.gracefulShutdownUnit = settingsBuilder.gracefulShutdownUnit;
   }
 
-  public Long getGracefulShutdownDuration() {
+  public Duration getGracefulShutdownDuration() {
     return gracefulShutdownDuration;
-  }
-
-  public TimeUnit getGracefulShutdownUnit() {
-    return gracefulShutdownUnit;
   }
 
   /**
@@ -70,8 +63,8 @@ public final class AsyncLineageProducerClientSettings extends LineageBaseSetting
    * method.
    */
   public static final class Builder extends LineageBaseSettings.Builder {
-    private Long gracefulShutdownDuration = 0L;
-    private TimeUnit gracefulShutdownUnit = TimeUnit.NANOSECONDS;
+    private Duration gracefulShutdownDuration = Duration.ZERO;
+
     private static Builder createDefault() {
       return new Builder(LineageStubSettings.newBuilder());
     }
@@ -83,7 +76,6 @@ public final class AsyncLineageProducerClientSettings extends LineageBaseSetting
     Builder(AsyncLineageProducerClientSettings settings) {
       super(settings);
       this.gracefulShutdownDuration = settings.gracefulShutdownDuration;
-      this.gracefulShutdownUnit = settings.gracefulShutdownUnit;
     }
 
     Builder(LineageStubSettings.Builder stubSettings) {
@@ -101,22 +93,13 @@ public final class AsyncLineageProducerClientSettings extends LineageBaseSetting
       return (SyncLineageProducerClientSettings.Builder) super.setConnectionCacheSettings(settings);
     }
 
-    public Builder setGracefulShutdownDuration(Long gracefulShutdownDuration) {
+    public Builder setGracefulShutdownDuration(Duration gracefulShutdownDuration) {
       this.gracefulShutdownDuration = gracefulShutdownDuration;
       return this;
     }
 
-    public Builder setGracefulShutdownTimeUnit(TimeUnit gracefulShutdownUnit) {
-      this.gracefulShutdownUnit = gracefulShutdownUnit;
-      return this;
-    }
-
-    public Long getGracefulShutdownDuration() {
+    public Duration getGracefulShutdownDuration() {
       return gracefulShutdownDuration;
-    }
-
-    public TimeUnit getGracefulShutdownUnit() {
-      return gracefulShutdownUnit;
     }
 
     @Override

--- a/lib/src/main/java/com/google/cloud/datalineage/producerclient/v1/SyncLineageProducerClient.java
+++ b/lib/src/main/java/com/google/cloud/datalineage/producerclient/v1/SyncLineageProducerClient.java
@@ -71,83 +71,63 @@ public final class SyncLineageProducerClient implements SyncLineageClient {
 
   @Override
   public void deleteLineageEvent(DeleteLineageEventRequest request) {
-    if (log.isDebugEnabled()) {
-      log.debug("Deleting lineage event: {}", request.getName());
-    }
+    log.debug("Deleting lineage event: {}", request.getName());
     ApiExceptions.callAndTranslateApiException(client.deleteLineageEvent(request));
   }
 
   @Override
   public void deleteProcess(DeleteProcessRequest request)
       throws ExecutionException, InterruptedException {
-    if (log.isDebugEnabled()) {
-      log.debug("Deleting process: {}", request.getName());
-    }
+    log.debug("Deleting process: {}", request.getName());
     client.deleteProcess(request).get();
   }
 
   @Override
   public void deleteRun(DeleteRunRequest request) throws ExecutionException, InterruptedException {
-    if (log.isDebugEnabled()) {
-      log.debug("Deleting run: {}", request.getName());
-    }
+    log.debug("Deleting run: {}", request.getName());
     client.deleteRun(request).get();
   }
 
   @Override
   public LineageEvent getLineageEvent(GetLineageEventRequest request) {
-    if (log.isDebugEnabled()) {
-      log.debug("Getting lineage event: {}", request.getName());
-    }
+    log.debug("Getting lineage event: {}", request.getName());
     return ApiExceptions.callAndTranslateApiException(client.getLineageEvent(request));
   }
 
   @Override
   public Process getProcess(GetProcessRequest request) {
-    if (log.isDebugEnabled()) {
-      log.debug("Getting process: {}", request.getName());
-    }
+    log.debug("Getting process: {}", request.getName());
     return ApiExceptions.callAndTranslateApiException(client.getProcess(request));
   }
 
   @Override
   public Run getRun(GetRunRequest request) {
-    if (log.isDebugEnabled()) {
-      log.debug("Getting run: {}", request.getName());
-    }
+    log.debug("Getting run: {}", request.getName());
     return ApiExceptions.callAndTranslateApiException(client.getRun(request));
   }
 
   @Override
   public ListLineageEventsPagedResponse listLineageEvents(ListLineageEventsRequest request) {
-    if (log.isDebugEnabled()) {
-      log.debug("Listing lineage events with request: {}", request);
-    }
+    log.debug("Listing lineage events for parent: {}", request.getParent());
     return ApiExceptions.callAndTranslateApiException(client.listLineageEvents(request));
   }
 
   @Override
   public ListProcessesPagedResponse listProcesses(ListProcessesRequest request) {
-    if (log.isDebugEnabled()) {
-      log.debug("Listing processes with request: {}", request);
-    }
+    log.debug("Listing processes for parent: {}", request.getParent());
     return ApiExceptions.callAndTranslateApiException(client.listProcesses(request));
   }
 
   @Override
   public ListRunsPagedResponse listRuns(ListRunsRequest request) {
-    if (log.isDebugEnabled()) {
-      log.debug("Listing runs with request: {}", request);
-    }
+    log.debug("Listing runs for parent: {}", request.getParent());
     return ApiExceptions.callAndTranslateApiException(client.listRuns(request));
   }
 
   @Override
   public ProcessOpenLineageRunEventResponse processOpenLineageRunEvent(
       ProcessOpenLineageRunEventRequest request) {
-    if (log.isDebugEnabled()) {
-      log.debug("Processing OpenLineage run event: {}", request.getOpenLineage());
-    }
+    log.debug("Processing OpenLineage run event: {}", request.getOpenLineage());
     return ApiExceptions.callAndTranslateApiException(client.processOpenLineageRunEvent(request));
   }
 

--- a/lib/src/main/java/com/google/cloud/datalineage/producerclient/v1/SyncLineageProducerClient.java
+++ b/lib/src/main/java/com/google/cloud/datalineage/producerclient/v1/SyncLineageProducerClient.java
@@ -35,8 +35,7 @@ import com.google.cloud.datacatalog.lineage.v1.Run;
 import java.io.IOException;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import lombok.extern.slf4j.Slf4j;
 
 /**
  * * Sync lineage producer client.
@@ -44,9 +43,8 @@ import org.slf4j.LoggerFactory;
  * <p>Implements SyncLineageClient using client library. This implementation also provides support
  * for connection cache.
  */
+@Slf4j
 public final class SyncLineageProducerClient implements SyncLineageClient {
-
-  private static final Logger logger = LoggerFactory.getLogger(SyncLineageProducerClient.class);
 
   public static SyncLineageProducerClient create() throws IOException {
     return create(SyncLineageProducerClientSettings.newBuilder().build());
@@ -73,8 +71,8 @@ public final class SyncLineageProducerClient implements SyncLineageClient {
 
   @Override
   public void deleteLineageEvent(DeleteLineageEventRequest request) {
-    if (logger.isDebugEnabled()) {
-      logger.debug("Deleting lineage event: {}", request.getName());
+    if (log.isDebugEnabled()) {
+      log.debug("Deleting lineage event: {}", request.getName());
     }
     ApiExceptions.callAndTranslateApiException(client.deleteLineageEvent(request));
   }
@@ -82,64 +80,64 @@ public final class SyncLineageProducerClient implements SyncLineageClient {
   @Override
   public void deleteProcess(DeleteProcessRequest request)
       throws ExecutionException, InterruptedException {
-    if (logger.isDebugEnabled()) {
-      logger.debug("Deleting process: {}", request.getName());
+    if (log.isDebugEnabled()) {
+      log.debug("Deleting process: {}", request.getName());
     }
     client.deleteProcess(request).get();
   }
 
   @Override
   public void deleteRun(DeleteRunRequest request) throws ExecutionException, InterruptedException {
-    if (logger.isDebugEnabled()) {
-      logger.debug("Deleting run: {}", request.getName());
+    if (log.isDebugEnabled()) {
+      log.debug("Deleting run: {}", request.getName());
     }
     client.deleteRun(request).get();
   }
 
   @Override
   public LineageEvent getLineageEvent(GetLineageEventRequest request) {
-    if (logger.isDebugEnabled()) {
-      logger.debug("Getting lineage event: {}", request.getName());
+    if (log.isDebugEnabled()) {
+      log.debug("Getting lineage event: {}", request.getName());
     }
     return ApiExceptions.callAndTranslateApiException(client.getLineageEvent(request));
   }
 
   @Override
   public Process getProcess(GetProcessRequest request) {
-    if (logger.isDebugEnabled()) {
-      logger.debug("Getting process: {}", request.getName());
+    if (log.isDebugEnabled()) {
+      log.debug("Getting process: {}", request.getName());
     }
     return ApiExceptions.callAndTranslateApiException(client.getProcess(request));
   }
 
   @Override
   public Run getRun(GetRunRequest request) {
-    if (logger.isDebugEnabled()) {
-      logger.debug("Getting run: {}", request.getName());
+    if (log.isDebugEnabled()) {
+      log.debug("Getting run: {}", request.getName());
     }
     return ApiExceptions.callAndTranslateApiException(client.getRun(request));
   }
 
   @Override
   public ListLineageEventsPagedResponse listLineageEvents(ListLineageEventsRequest request) {
-    if (logger.isDebugEnabled()) {
-      logger.debug("Listing lineage events with request: {}", request);
+    if (log.isDebugEnabled()) {
+      log.debug("Listing lineage events with request: {}", request);
     }
     return ApiExceptions.callAndTranslateApiException(client.listLineageEvents(request));
   }
 
   @Override
   public ListProcessesPagedResponse listProcesses(ListProcessesRequest request) {
-    if (logger.isDebugEnabled()) {
-      logger.debug("Listing processes with request: {}", request);
+    if (log.isDebugEnabled()) {
+      log.debug("Listing processes with request: {}", request);
     }
     return ApiExceptions.callAndTranslateApiException(client.listProcesses(request));
   }
 
   @Override
   public ListRunsPagedResponse listRuns(ListRunsRequest request) {
-    if (logger.isDebugEnabled()) {
-      logger.debug("Listing runs with request: {}", request);
+    if (log.isDebugEnabled()) {
+      log.debug("Listing runs with request: {}", request);
     }
     return ApiExceptions.callAndTranslateApiException(client.listRuns(request));
   }
@@ -147,8 +145,8 @@ public final class SyncLineageProducerClient implements SyncLineageClient {
   @Override
   public ProcessOpenLineageRunEventResponse processOpenLineageRunEvent(
       ProcessOpenLineageRunEventRequest request) {
-    if (logger.isDebugEnabled()) {
-      logger.debug("Processing OpenLineage run event: {}", request.getOpenLineage());
+    if (log.isDebugEnabled()) {
+      log.debug("Processing OpenLineage run event: {}", request.getOpenLineage());
     }
     return ApiExceptions.callAndTranslateApiException(client.processOpenLineageRunEvent(request));
   }

--- a/lib/src/main/java/com/google/cloud/datalineage/producerclient/v1/SyncLineageProducerClient.java
+++ b/lib/src/main/java/com/google/cloud/datalineage/producerclient/v1/SyncLineageProducerClient.java
@@ -35,6 +35,8 @@ import com.google.cloud.datacatalog.lineage.v1.Run;
 import java.io.IOException;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * * Sync lineage producer client.
@@ -43,6 +45,8 @@ import java.util.concurrent.TimeUnit;
  * for connection cache.
  */
 public final class SyncLineageProducerClient implements SyncLineageClient {
+
+  private static final Logger logger = LoggerFactory.getLogger(SyncLineageProducerClient.class);
 
   public static SyncLineageProducerClient create() throws IOException {
     return create(SyncLineageProducerClientSettings.newBuilder().build());
@@ -69,53 +73,83 @@ public final class SyncLineageProducerClient implements SyncLineageClient {
 
   @Override
   public void deleteLineageEvent(DeleteLineageEventRequest request) {
+    if (logger.isDebugEnabled()) {
+      logger.debug("Deleting lineage event: {}", request.getName());
+    }
     ApiExceptions.callAndTranslateApiException(client.deleteLineageEvent(request));
   }
 
   @Override
   public void deleteProcess(DeleteProcessRequest request)
       throws ExecutionException, InterruptedException {
+    if (logger.isDebugEnabled()) {
+      logger.debug("Deleting process: {}", request.getName());
+    }
     client.deleteProcess(request).get();
   }
 
   @Override
   public void deleteRun(DeleteRunRequest request) throws ExecutionException, InterruptedException {
+    if (logger.isDebugEnabled()) {
+      logger.debug("Deleting run: {}", request.getName());
+    }
     client.deleteRun(request).get();
   }
 
   @Override
   public LineageEvent getLineageEvent(GetLineageEventRequest request) {
+    if (logger.isDebugEnabled()) {
+      logger.debug("Getting lineage event: {}", request.getName());
+    }
     return ApiExceptions.callAndTranslateApiException(client.getLineageEvent(request));
   }
 
   @Override
   public Process getProcess(GetProcessRequest request) {
+    if (logger.isDebugEnabled()) {
+      logger.debug("Getting process: {}", request.getName());
+    }
     return ApiExceptions.callAndTranslateApiException(client.getProcess(request));
   }
 
   @Override
   public Run getRun(GetRunRequest request) {
+    if (logger.isDebugEnabled()) {
+      logger.debug("Getting run: {}", request.getName());
+    }
     return ApiExceptions.callAndTranslateApiException(client.getRun(request));
   }
 
   @Override
   public ListLineageEventsPagedResponse listLineageEvents(ListLineageEventsRequest request) {
+    if (logger.isDebugEnabled()) {
+      logger.debug("Listing lineage events with request: {}", request);
+    }
     return ApiExceptions.callAndTranslateApiException(client.listLineageEvents(request));
   }
 
   @Override
   public ListProcessesPagedResponse listProcesses(ListProcessesRequest request) {
+    if (logger.isDebugEnabled()) {
+      logger.debug("Listing processes with request: {}", request);
+    }
     return ApiExceptions.callAndTranslateApiException(client.listProcesses(request));
   }
 
   @Override
   public ListRunsPagedResponse listRuns(ListRunsRequest request) {
+    if (logger.isDebugEnabled()) {
+      logger.debug("Listing runs with request: {}", request);
+    }
     return ApiExceptions.callAndTranslateApiException(client.listRuns(request));
   }
 
   @Override
   public ProcessOpenLineageRunEventResponse processOpenLineageRunEvent(
       ProcessOpenLineageRunEventRequest request) {
+    if (logger.isDebugEnabled()) {
+      logger.debug("Processing OpenLineage run event: {}", request.getOpenLineage());
+    }
     return ApiExceptions.callAndTranslateApiException(client.processOpenLineageRunEvent(request));
   }
 

--- a/lib/src/test/java/com/google/cloud/datalineage/producerclient/StandardApiEnablementCacheLoggingTest.java
+++ b/lib/src/test/java/com/google/cloud/datalineage/producerclient/StandardApiEnablementCacheLoggingTest.java
@@ -1,0 +1,164 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.cloud.datalineage.producerclient;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.LoggerContext;
+import com.google.cloud.datalineage.producerclient.test.TestLogAppender;
+import java.time.Clock;
+import java.time.Duration;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.slf4j.LoggerFactory;
+
+/** Tests logging functionality in StandardApiEnablementCache. */
+@RunWith(JUnit4.class)
+public class StandardApiEnablementCacheLoggingTest {
+
+  private TestLogAppender testAppender;
+  private Logger logger;
+  private StandardApiEnablementCache cache;
+
+  @Before
+  public void setUp() {
+    // Set up logging capture
+    LoggerContext loggerContext = (LoggerContext) LoggerFactory.getILoggerFactory();
+    logger = loggerContext.getLogger(StandardApiEnablementCache.class);
+
+    testAppender = new TestLogAppender();
+    testAppender.setContext(loggerContext);
+    testAppender.start();
+
+    logger.addAppender(testAppender);
+    logger.setLevel(Level.DEBUG); // Enable debug logging for tests
+
+    ApiEnablementCacheOptions options =
+        ApiEnablementCacheOptions.newBuilder()
+            .setCacheSize(100)
+            .setDefaultCacheDisabledStatusTime(Duration.ofMinutes(5))
+            .setClock(Clock.systemDefaultZone())
+            .build();
+
+    cache = new StandardApiEnablementCache(options);
+  }
+
+  @After
+  public void tearDown() {
+    if (logger != null && testAppender != null) {
+      logger.detachAppender(testAppender);
+    }
+    if (testAppender != null) {
+      testAppender.stop();
+    }
+  }
+
+  @Test
+  public void testCacheInitializationLogging() {
+    // Verify that cache initialization is logged
+    boolean found =
+        testAppender.getMessagesAtLevel(Level.DEBUG).stream()
+            .anyMatch(
+                log ->
+                    log.contains("Initializing StandardApiEnablementCache with cache size: 100")
+                        && log.contains("default disabled duration: PT5M"));
+    assertThat(found).isTrue();
+  }
+
+  @Test
+  public void testMarkServiceAsDisabledLogging() {
+    testAppender.clear(); // Clear logs from setup
+
+    String projectName = "test-project";
+    Duration duration = Duration.ofMinutes(10);
+
+    cache.markServiceAsDisabled(projectName, duration);
+
+    // Verify that marking service as disabled is logged
+    boolean found =
+        testAppender.getMessagesAtLevel(Level.WARN).stream()
+            .anyMatch(
+                log ->
+                    log.contains(
+                        "Marking service as disabled for project 'test-project'"
+                            + " for duration: PT10M"));
+    assertThat(found).isTrue();
+  }
+
+  @Test
+  public void testIsServiceMarkedAsDisabledLogging_NotFound() {
+    testAppender.clear(); // Clear logs from setup
+
+    String projectName = "non-existent-project";
+
+    boolean result = cache.isServiceMarkedAsDisabled(projectName);
+
+    assertThat(result).isFalse();
+    boolean found =
+        testAppender.getMessagesAtLevel(Level.DEBUG).stream()
+            .anyMatch(
+                log -> log.contains("No cache entry found for project: non-existent-project"));
+    assertThat(found).isTrue();
+  }
+
+  @Test
+  public void testIsServiceMarkedAsDisabledLogging_Found() {
+    // First mark the service as disabled
+    cache.markServiceAsDisabled("test-project", Duration.ofMinutes(5));
+
+    // Clear logs to focus on the check operation
+    testAppender.clear();
+
+    boolean result = cache.isServiceMarkedAsDisabled("test-project");
+
+    assertThat(result).isTrue();
+    boolean found =
+        testAppender.getMessagesAtLevel(Level.DEBUG).stream()
+            .anyMatch(
+                log ->
+                    log.contains("Service is marked as disabled for project: test-project until"));
+    assertThat(found).isTrue();
+  }
+
+  @Test
+  public void testIsServiceMarkedAsDisabledLogging_Expired() {
+    // Mark service as disabled for a very short duration
+    cache.markServiceAsDisabled("test-project", Duration.ofNanos(1));
+
+    // Wait a bit to ensure expiration
+    try {
+      Thread.sleep(10);
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+    }
+
+    // Clear logs to focus on the check operation
+    testAppender.clear();
+
+    boolean result = cache.isServiceMarkedAsDisabled("test-project");
+
+    assertThat(result).isFalse();
+    boolean found =
+        testAppender.getMessagesAtLevel(Level.DEBUG).stream()
+            .anyMatch(
+                log -> log.contains("Service disability has expired for project: test-project"));
+    assertThat(found).isTrue();
+  }
+}

--- a/lib/src/test/java/com/google/cloud/datalineage/producerclient/helpers/GrpcHelperLoggingTest.java
+++ b/lib/src/test/java/com/google/cloud/datalineage/producerclient/helpers/GrpcHelperLoggingTest.java
@@ -1,0 +1,180 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.cloud.datalineage.producerclient.helpers;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.assertThrows;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.LoggerContext;
+import com.google.cloud.datalineage.producerclient.test.TestLogAppender;
+import com.google.protobuf.Any;
+import com.google.rpc.ErrorInfo;
+import com.google.rpc.Status;
+import io.grpc.StatusRuntimeException;
+import io.grpc.protobuf.StatusProto;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.slf4j.LoggerFactory;
+
+/** Tests logging functionality in GrpcHelper. */
+@RunWith(JUnit4.class)
+public class GrpcHelperLoggingTest {
+
+  private TestLogAppender testAppender;
+  private Logger logger;
+
+  @Before
+  public void setUp() {
+    // Set up logging capture
+    LoggerContext loggerContext = (LoggerContext) LoggerFactory.getILoggerFactory();
+    logger = loggerContext.getLogger(GrpcHelper.class);
+
+    testAppender = new TestLogAppender();
+    testAppender.setContext(loggerContext);
+    testAppender.start();
+
+    logger.addAppender(testAppender);
+    logger.setLevel(Level.DEBUG); // Enable debug logging for tests
+  }
+
+  @After
+  public void tearDown() {
+    if (logger != null && testAppender != null) {
+      logger.detachAppender(testAppender);
+    }
+    if (testAppender != null) {
+      testAppender.stop();
+    }
+  }
+
+  @Test
+  public void testGetReason_ValidErrorInfo_LogsSuccess() {
+    testAppender.clear(); // Clear any existing logs
+
+    // Create an ErrorInfo with a reason
+    ErrorInfo errorInfo =
+        ErrorInfo.newBuilder().setReason("API_DISABLED").setDomain("googleapis.com").build();
+
+    // Create a Status with the ErrorInfo
+    Status status =
+        Status.newBuilder()
+            .setCode(com.google.rpc.Code.FAILED_PRECONDITION_VALUE)
+            .setMessage("API is disabled")
+            .addDetails(Any.pack(errorInfo))
+            .build();
+
+    // Create a gRPC exception from the status
+    StatusRuntimeException exception = StatusProto.toStatusRuntimeException(status);
+
+    // Call the method
+    String reason = GrpcHelper.getReason(exception);
+
+    // Verify the result
+    assertThat(reason).isEqualTo("API_DISABLED");
+
+    // Verify debug logging
+    boolean found =
+        testAppender.getMessagesAtLevel(Level.DEBUG).stream()
+            .anyMatch(
+                log -> log.contains("Successfully extracted reason from ErrorInfo: API_DISABLED"));
+    assertThat(found).isTrue();
+  }
+
+  @Test
+  public void testGetReason_InvalidProtocolBuffer_LogsError() {
+    testAppender.clear(); // Clear any existing logs
+
+    // Create a malformed Any that can't be unpacked
+    Any invalidAny =
+        Any.newBuilder()
+            .setTypeUrl("type.googleapis.com/google.rpc.ErrorInfo")
+            .setValue(com.google.protobuf.ByteString.copyFromUtf8("invalid-data"))
+            .build();
+
+    Status status =
+        Status.newBuilder()
+            .setCode(com.google.rpc.Code.FAILED_PRECONDITION_VALUE)
+            .setMessage("API is disabled")
+            .addDetails(invalidAny)
+            .build();
+
+    StatusRuntimeException exception = StatusProto.toStatusRuntimeException(status);
+
+    // Call the method and expect an exception
+    IllegalArgumentException thrown =
+        assertThrows(IllegalArgumentException.class, () -> GrpcHelper.getReason(exception));
+
+    assertThat(thrown.getMessage()).contains("Invalid protocol buffer message");
+
+    // Verify error logging
+    boolean found =
+        testAppender.getMessagesAtLevel(Level.ERROR).stream()
+            .anyMatch(
+                log -> log.contains("Invalid protocol buffer message while extracting ErrorInfo"));
+    assertThat(found).isTrue();
+  }
+
+  @Test
+  public void testGetReason_NoErrorInfo_LogsWarning() {
+    testAppender.clear(); // Clear any existing logs
+
+    // Create a Status without ErrorInfo
+    Status status =
+        Status.newBuilder()
+            .setCode(com.google.rpc.Code.FAILED_PRECONDITION_VALUE)
+            .setMessage("API is disabled")
+            .build();
+
+    StatusRuntimeException exception = StatusProto.toStatusRuntimeException(status);
+
+    // Call the method and expect an exception
+    IllegalArgumentException thrown =
+        assertThrows(IllegalArgumentException.class, () -> GrpcHelper.getReason(exception));
+
+    assertThat(thrown.getMessage()).contains("Message does not contain ErrorInfo");
+
+    // Verify warning logging
+    boolean found =
+        testAppender.getMessagesAtLevel(Level.WARN).stream()
+            .anyMatch(
+                log ->
+                    log.contains(
+                        "Message does not contain ErrorInfo for exception:"
+                            + " FAILED_PRECONDITION: API is disabled"));
+    assertThat(found).isTrue();
+  }
+
+  @Test
+  public void testGetReason_NonGrpcException_ThrowsException() {
+    testAppender.clear(); // Clear any existing logs
+
+    // Create a non-gRPC exception
+    RuntimeException nonGrpcException = new RuntimeException("Not a gRPC exception");
+
+    // Call the method and expect an exception
+    IllegalArgumentException thrown =
+        assertThrows(IllegalArgumentException.class, () -> GrpcHelper.getReason(nonGrpcException));
+
+    assertThat(thrown.getMessage()).contains("Provided throwable is not a Grpc exception");
+
+    // Note: The current implementation doesn't log this case, but if we wanted to test it,
+    // we would need to modify the GrpcHelper to add logging for this scenario.
+  }
+}

--- a/lib/src/test/java/com/google/cloud/datalineage/producerclient/test/TestLogAppender.java
+++ b/lib/src/test/java/com/google/cloud/datalineage/producerclient/test/TestLogAppender.java
@@ -1,0 +1,56 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.cloud.datalineage.producerclient.test;
+
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.AppenderBase;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/** Test appender for capturing log messages during tests. */
+public class TestLogAppender extends AppenderBase<ILoggingEvent> {
+  private final List<ILoggingEvent> events = Collections.synchronizedList(new ArrayList<>());
+
+  @Override
+  protected void append(ILoggingEvent event) {
+    events.add(event);
+  }
+
+  public List<ILoggingEvent> getEvents() {
+    return new ArrayList<>(events);
+  }
+
+  public List<String> getMessages() {
+    return events.stream()
+        .map(ILoggingEvent::getFormattedMessage)
+        .collect(ArrayList::new, ArrayList::add, ArrayList::addAll);
+  }
+
+  public List<String> getMessagesAtLevel(ch.qos.logback.classic.Level level) {
+    return events.stream()
+        .filter(event -> event.getLevel().equals(level))
+        .map(ILoggingEvent::getFormattedMessage)
+        .collect(ArrayList::new, ArrayList::add, ArrayList::addAll);
+  }
+
+  public void clear() {
+    events.clear();
+  }
+
+  public int size() {
+    return events.size();
+  }
+}

--- a/lib/src/test/java/com/google/cloud/datalineage/producerclient/v1/AsyncLineageProducerClientLoggingTest.java
+++ b/lib/src/test/java/com/google/cloud/datalineage/producerclient/v1/AsyncLineageProducerClientLoggingTest.java
@@ -1,0 +1,208 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package com.google.cloud.datalineage.producerclient.v1;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.LoggerContext;
+import com.google.cloud.datacatalog.lineage.v1.DeleteLineageEventRequest;
+import com.google.cloud.datacatalog.lineage.v1.GetLineageEventRequest;
+import com.google.cloud.datacatalog.lineage.v1.ProcessOpenLineageRunEventRequest;
+import com.google.cloud.datalineage.producerclient.test.TestLogAppender;
+import java.io.IOException;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.slf4j.LoggerFactory;
+import org.threeten.bp.Duration;
+
+/** Tests logging functionality in AsyncLineageProducerClient. */
+@RunWith(JUnit4.class)
+public class AsyncLineageProducerClientLoggingTest {
+  private TestLogAppender testAppender;
+  private Logger logger;
+  private AsyncLineageProducerClient client;
+
+  @Before
+  public void setUp() throws IOException {
+    // Set up logging capture
+    LoggerContext loggerContext = (LoggerContext) LoggerFactory.getILoggerFactory();
+    logger = loggerContext.getLogger(AsyncLineageProducerClient.class);
+
+    testAppender = new TestLogAppender();
+    testAppender.setContext(loggerContext);
+    testAppender.start();
+
+    logger.addAppender(testAppender);
+    logger.setLevel(Level.DEBUG); // Enable debug logging for tests
+    // Create client with settings for testing
+    AsyncLineageProducerClientSettings settings =
+        AsyncLineageProducerClientSettings.newBuilder()
+            .setGracefulShutdownDuration(Duration.ofSeconds(1))
+            .build();
+    client = AsyncLineageProducerClient.create(settings);
+  }
+
+  @After
+  public void tearDown() {
+    if (client != null) {
+      client.shutdownNow();
+    }
+    if (logger != null && testAppender != null) {
+      logger.detachAppender(testAppender);
+    }
+    if (testAppender != null) {
+      testAppender.stop();
+    }
+  }
+
+  @Test
+  public void testClientCreationLogging() {
+    // Verify that client creation is logged
+    assertThat(testAppender.getMessagesAtLevel(Level.DEBUG))
+        .contains("Creating AsyncLineageProducerClient with graceful shutdown duration: PT1S");
+  }
+
+  @Test
+  public void testDeleteLineageEventLogging() {
+    testAppender.clear(); // Clear logs from setup
+
+    DeleteLineageEventRequest request =
+        DeleteLineageEventRequest.newBuilder()
+            .setName(
+                "projects/test-project/locations/us-central1/processes/test-process/runs/test-run/lineageEvents/test-event")
+            .build();
+    try {
+      client.deleteLineageEvent(request);
+    } catch (Exception e) {
+      // Expected to fail in test environment, we're just testing logging
+    }
+    // Verify the debug log was created
+    boolean found =
+        testAppender.getMessagesAtLevel(Level.DEBUG).stream()
+            .anyMatch(
+                log ->
+                    log.contains(
+                        "Deleting lineage event: projects/test-project/locations/us-central1/processes/test-process/runs/test-run/lineageEvents/test-event"));
+    assertThat(found).isTrue();
+  }
+
+  @Test
+  public void testGetLineageEventLogging() {
+    testAppender.clear(); // Clear logs from setup
+
+    GetLineageEventRequest request =
+        GetLineageEventRequest.newBuilder()
+            .setName(
+                "projects/test-project/locations/us-central1/processes/test-process/runs/test-run/lineageEvents/test-event")
+            .build();
+    try {
+      client.getLineageEvent(request);
+    } catch (Exception e) {
+      // Expected to fail in test environment, we're just testing logging
+    }
+    // Verify the debug log was created
+    boolean found =
+        testAppender.getMessagesAtLevel(Level.DEBUG).stream()
+            .anyMatch(
+                log ->
+                    log.contains(
+                        "Getting lineage event: projects/test-project/locations/us-central1/processes/test-process/runs/test-run/lineageEvents/test-event"));
+    assertThat(found).isTrue();
+  }
+
+  @Test
+  public void testProcessOpenLineageRunEventLogging() {
+    testAppender.clear(); // Clear logs from setup
+
+    ProcessOpenLineageRunEventRequest request =
+        ProcessOpenLineageRunEventRequest.newBuilder()
+            .setParent("projects/test-project/locations/us-central1")
+            .build();
+    try {
+      client.processOpenLineageRunEvent(request);
+    } catch (Exception e) {
+      // Expected to fail in test environment, we're just testing logging
+    }
+    // Verify the debug log was created
+    boolean found =
+        testAppender.getMessagesAtLevel(Level.DEBUG).stream()
+            .anyMatch(log -> log.contains("Processing OpenLineage run event:"));
+    assertThat(found).isTrue();
+  }
+
+  @Test
+  public void testGracefulShutdownLogging() throws Exception {
+    testAppender.clear(); // Clear logs from setup
+
+    // Test graceful shutdown logging
+    client.close();
+    // Verify shutdown logging
+    boolean found =
+        testAppender.getMessagesAtLevel(Level.DEBUG).stream()
+            .anyMatch(log -> log.contains("Starting graceful shutdown with duration: PT1S"));
+    assertThat(found).isTrue();
+  }
+
+  @Test
+  public void testShutdownTimeoutLogging() throws Exception {
+    // Create a client with very short timeout to trigger timeout warning
+    AsyncLineageProducerClientSettings shortTimeoutSettings =
+        AsyncLineageProducerClientSettings.newBuilder()
+            .setGracefulShutdownDuration(Duration.ofMillis(1)) // Very short timeout
+            .build();
+    AsyncLineageProducerClient shortTimeoutClient =
+        AsyncLineageProducerClient.create(shortTimeoutSettings);
+
+    // Start some background operations to create work that needs shutdown
+    // This creates background threads and operations that need time to shut down
+    for (int i = 0; i < 10; i++) {
+      try {
+        GetLineageEventRequest request =
+            GetLineageEventRequest.newBuilder()
+                .setName(
+                    "projects/test-project/locations/us-central1/processes/test-process/runs/test-run/lineageEvents/test-event-"
+                        + i)
+                .build();
+        shortTimeoutClient.getLineageEvent(request);
+      } catch (Exception e) {
+        // Ignore exceptions, we just want to create background work
+      }
+    }
+
+    testAppender.clear(); // Clear logs from setup
+
+    try {
+      shortTimeoutClient.close();
+    } catch (Exception e) {
+      // Ignore any exceptions, we're testing logging
+    }
+
+    // Verify timeout warning was logged
+    boolean found =
+        testAppender.getMessagesAtLevel(Level.WARN).stream()
+            .anyMatch(
+                log ->
+                    log.contains(
+                        "AsyncLineageProducerClient did not terminate within the"
+                            + " graceful shutdown duration"));
+    assertThat(found).isTrue();
+
+    shortTimeoutClient.shutdownNow();
+  }
+}

--- a/lib/src/test/java/com/google/cloud/datalineage/producerclient/v1/AsyncLineageProducerClientSettingsTest.java
+++ b/lib/src/test/java/com/google/cloud/datalineage/producerclient/v1/AsyncLineageProducerClientSettingsTest.java
@@ -27,8 +27,6 @@ import org.junit.Test;
 import org.mockito.Mockito;
 import org.threeten.bp.Duration;
 
-import java.util.concurrent.TimeUnit;
-
 /** * Test suite for AsyncLineageProducerClientSettingsTest */
 public class AsyncLineageProducerClientSettingsTest {
 
@@ -205,7 +203,7 @@ public class AsyncLineageProducerClientSettingsTest {
   public void builder_setGracefulShutdownDuration() {
     AsyncLineageProducerClientSettings.Builder builder =
         AsyncLineageProducerClientSettings.newBuilder();
-    Long gracefulShutdownDuration = 1000L; // 1 second
+    Duration gracefulShutdownDuration = Duration.ofSeconds(1); // 1 second
 
     AsyncLineageProducerClientSettings.Builder resultBuilder =
         builder.setGracefulShutdownDuration(gracefulShutdownDuration);
@@ -213,17 +211,4 @@ public class AsyncLineageProducerClientSettingsTest {
     assertNotNull(resultBuilder);
     assertEquals(gracefulShutdownDuration, resultBuilder.getGracefulShutdownDuration());
   }
-
-  @Test
-    public void builder_setGracefulShutdownUnit() {
-        AsyncLineageProducerClientSettings.Builder builder =
-            AsyncLineageProducerClientSettings.newBuilder();
-        TimeUnit gracefulShutdownUnit = TimeUnit.SECONDS;
-
-        AsyncLineageProducerClientSettings.Builder resultBuilder =
-            builder.setGracefulShutdownTimeUnit(gracefulShutdownUnit);
-
-        assertNotNull(resultBuilder);
-        assertEquals(gracefulShutdownUnit, resultBuilder.getGracefulShutdownUnit());
-    }
 }

--- a/lib/src/test/java/com/google/cloud/datalineage/producerclient/v1/AsyncLineageProducerClientSettingsTest.java
+++ b/lib/src/test/java/com/google/cloud/datalineage/producerclient/v1/AsyncLineageProducerClientSettingsTest.java
@@ -27,6 +27,8 @@ import org.junit.Test;
 import org.mockito.Mockito;
 import org.threeten.bp.Duration;
 
+import java.util.concurrent.TimeUnit;
+
 /** * Test suite for AsyncLineageProducerClientSettingsTest */
 public class AsyncLineageProducerClientSettingsTest {
 
@@ -198,4 +200,30 @@ public class AsyncLineageProducerClientSettingsTest {
     assertNotNull(resultBuilder);
     assertEquals(mockExecutorProvider, resultBuilder.getBackgroundExecutorProvider());
   }
+
+  @Test
+  public void builder_setGracefulShutdownDuration() {
+    AsyncLineageProducerClientSettings.Builder builder =
+        AsyncLineageProducerClientSettings.newBuilder();
+    Long gracefulShutdownDuration = 1000L; // 1 second
+
+    AsyncLineageProducerClientSettings.Builder resultBuilder =
+        builder.setGracefulShutdownDuration(gracefulShutdownDuration);
+
+    assertNotNull(resultBuilder);
+    assertEquals(gracefulShutdownDuration, resultBuilder.getGracefulShutdownDuration());
+  }
+
+  @Test
+    public void builder_setGracefulShutdownUnit() {
+        AsyncLineageProducerClientSettings.Builder builder =
+            AsyncLineageProducerClientSettings.newBuilder();
+        TimeUnit gracefulShutdownUnit = TimeUnit.SECONDS;
+
+        AsyncLineageProducerClientSettings.Builder resultBuilder =
+            builder.setGracefulShutdownTimeUnit(gracefulShutdownUnit);
+
+        assertNotNull(resultBuilder);
+        assertEquals(gracefulShutdownUnit, resultBuilder.getGracefulShutdownUnit());
+    }
 }

--- a/lib/src/test/java/com/google/cloud/datalineage/producerclient/v1/AsyncLineageProducerClientTest.java
+++ b/lib/src/test/java/com/google/cloud/datalineage/producerclient/v1/AsyncLineageProducerClientTest.java
@@ -107,7 +107,7 @@ public class AsyncLineageProducerClientTest {
   public void gracefulShutdown_awaitsTerminationIfSet() throws Exception {
     // objects passed to lambda must be final or effectively final, so we use arrays to store the
     // values
-    Duration[] resultAwaitTerminationTime = new Duration[1];
+    long[] resultAwaitTerminationTime = new long[1];
     AsyncLineageProducerClient asyncLineageProducerClient =
         AsyncLineageProducerClient.create(basicLineageClient, Duration.ofSeconds(1));
     doAnswer(
@@ -121,8 +121,8 @@ public class AsyncLineageProducerClientTest {
     asyncLineageProducerClient.close();
     // Verify that the awaitTermination was called with the expected values
     // we cannot get the resultAwaitTerminationTime exactly, so we check reasonable scope
-    assertThat(resultAwaitTerminationTime[0]).isAtLeast(Duration.ZERO);
-    assertThat(resultAwaitTerminationTime[0]).isAtMost(Duration.ofSeconds(1));
+    assertThat(Duration.ofNanos(resultAwaitTerminationTime[0])).isAtLeast(Duration.ZERO);
+    assertThat(Duration.ofNanos(resultAwaitTerminationTime[0])).isAtMost(Duration.ofSeconds(1));
   }
 
   private static Struct someOpenLineage() {

--- a/lib/src/test/resources/logback-test.xml
+++ b/lib/src/test/resources/logback-test.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <!-- Set specific logging levels for the data lineage producer client -->
+    <logger name="com.google.cloud.datalineage.producerclient" level="DEBUG"/>
+    
+    <root level="INFO">
+        <appender-ref ref="STDOUT"/>
+    </root>
+</configuration>


### PR DESCRIPTION
Related to Issues #25 and #28 

- Adds two new fields to `AsyncLineageProducerClient` that correspond to the ones used in awaitTermination
- Adds fields to `AsyncLineageProducerClientSettings` and its builder
- If graceful shutdown duration is set to more than zero, `close` and `shutdown` methods will block for given duration